### PR TITLE
Updates to MemoryMgr and Patterns

### DIFF
--- a/MemoryMgr.h
+++ b/MemoryMgr.h
@@ -68,20 +68,20 @@ namespace Memory
 	} while ( --count != 0 ); }
 #endif
 
-	template<typename Var, typename AT>
+	template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 	inline void		WriteOffsetValue(AT address, Var var)
 	{
 		intptr_t dstAddr = (intptr_t)address;
 		intptr_t srcAddr;
 		memcpy( &srcAddr, std::addressof(var), sizeof(srcAddr) );
-		*(int32_t*)dstAddr = static_cast<int32_t>(srcAddr - dstAddr - 4);
+		*(int32_t*)dstAddr = static_cast<int32_t>(srcAddr - dstAddr - (4 + extraBytesAfterOffset));
 	}
 
-	template<typename Var, typename AT>
+	template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 	inline void		ReadOffsetValue(AT address, Var& var)
 	{
 		intptr_t srcAddr = (intptr_t)address;
-		intptr_t dstAddr = srcAddr + 4 + *(int32_t*)srcAddr;
+		intptr_t dstAddr = srcAddr + (4 + extraBytesAfterOffset) + *(int32_t*)srcAddr;
 		var = {};
 		memcpy( std::addressof(var), &dstAddr, sizeof(dstAddr) );
 	}
@@ -150,16 +150,16 @@ namespace Memory
 			Memory::Nop(DynBaseAddress(address), count);
 		}
 
-		template<typename Var, typename AT>
+		template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 		inline void		WriteOffsetValue(AT address, Var var)
 		{
-			Memory::WriteOffsetValue(DynBaseAddress(address), var);
+			Memory::WriteOffsetValue<extraBytesAfterOffset>(DynBaseAddress(address), var);
 		}
 
-		template<typename Var, typename AT>
+		template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 		inline void		ReadOffsetValue(AT address, Var& var)
 		{
-			Memory::ReadOffsetValue(DynBaseAddress(address), var);
+			Memory::ReadOffsetValue<extraBytesAfterOffset>(DynBaseAddress(address), var);
 		}
 
 		template<typename AT, typename HT>
@@ -231,20 +231,20 @@ namespace Memory
 			VirtualProtect((void*)address, count, dwProtect, &dwProtect);
 		}
 
-		template<typename Var, typename AT>
+		template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 		inline void		WriteOffsetValue(AT address, Var var)
 		{
 			DWORD		dwProtect;
 
 			VirtualProtect((void*)address, 4, PAGE_EXECUTE_READWRITE, &dwProtect);
-			Memory::WriteOffsetValue(address, var);
+			Memory::WriteOffsetValue<extraBytesAfterOffset>(address, var);
 			VirtualProtect((void*)address, 4, dwProtect, &dwProtect);
 		}
 
-		template<typename Var, typename AT>
+		template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 		inline void		ReadOffsetValue(AT address, Var& var)
 		{
-			Memory::ReadOffsetValue(address, var);
+			Memory::ReadOffsetValue<extraBytesAfterOffset>(address, var);
 		}
 
 		template<typename AT, typename HT>
@@ -314,16 +314,16 @@ namespace Memory
 				VP::Nop(DynBaseAddress(address), count);
 			}
 
-			template<typename Var, typename AT>
+			template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 			inline void		WriteOffsetValue(AT address, Var var)
 			{
-				VP::WriteOffsetValue(DynBaseAddress(address), var);
+				VP::WriteOffsetValue<extraBytesAfterOffset>(DynBaseAddress(address), var);
 			}
 
-			template<typename Var, typename AT>
+			template<ptrdiff_t extraBytesAfterOffset = 0, typename Var, typename AT>
 			inline void		ReadOffsetValue(AT address, Var& var)
 			{
-				VP::ReadOffsetValue(DynBaseAddress(address), var);
+				VP::ReadOffsetValue<extraBytesAfterOffset>(DynBaseAddress(address), var);
 			}
 
 			template<typename AT, typename HT>

--- a/Patterns.h
+++ b/Patterns.h
@@ -57,6 +57,11 @@ namespace hook
 			char* ptr = reinterpret_cast<char*>(m_pointer);
 			return reinterpret_cast<T*>(ptr + offset);
 		}
+
+		uintptr_t get_uintptr(ptrdiff_t offset = 0) const
+		{
+			return reinterpret_cast<uintptr_t>(get<void>(offset));
+		}
 	};
 
 	namespace details
@@ -227,6 +232,11 @@ namespace hook
 		return pattern(std::move(pattern_string)).get_first<T>(offset);
 	}
 
+	inline auto get_pattern_uintptr(std::string_view pattern_string, ptrdiff_t offset = 0)
+	{
+		return pattern(std::move(pattern_string)).get_one().get_uintptr(offset);
+	}
+
 	namespace txn
 	{
 		using pattern = hook::basic_pattern<exception_err_policy>;
@@ -246,6 +256,11 @@ namespace hook
 		inline auto get_pattern(std::string_view pattern_string, ptrdiff_t offset = 0)
 		{
 			return pattern(std::move(pattern_string)).get_first<T>(offset);
+		}
+
+		inline auto get_pattern_uintptr(std::string_view pattern_string, ptrdiff_t offset = 0)
+		{
+			return pattern(std::move(pattern_string)).get_one().get_uintptr(offset);
 		}
 	}
 }


### PR DESCRIPTION
* Add an optional offset value to `WriteOffsetValue` and `ReadOffsetValue` to specify how many bytes come after an offset inside a patched instruction. Useful for patching cases like `mov [addr], val`.
* Add `get_pattern_uintptr` to get patterns implicitly casted to `uintptr_t`, so a typecast from `void*` is not needed.