### PR TITLE
Fixed: Edge cases in Trampoline::FindAndAllocateMem

### DIFF
--- a/Trampoline.h
+++ b/Trampoline.h
@@ -150,6 +150,16 @@ private:
 				uintptr_t alignedAddr = uintptr_t(MemoryInf.BaseAddress);
 				alignedAddr = (alignedAddr + granularity - 1) & ~uintptr_t(granularity - 1);
 
+				// We need to check both the start and the end of the region here.
+				// More specifically, for addresses after `addr`, we should check the 
+				// beginning of the region, and for addresses before `addr`, we should
+				// check the end of the region.
+
+				// This is because it's theoretically possible that the region is:
+				// - Below `addr`
+				// - Starts further away than `-2GiB`
+				// - Ends closer than `2GiB`
+				// And vice-versa for regions above `addr`.
 				uintptr_t alignedAddrEnd = uintptr_t(uintptr_t(MemoryInf.BaseAddress) + MemoryInf.RegionSize) - size;
 				alignedAddrEnd = RoundDown(alignedAddrEnd, granularity);
 

--- a/Trampoline.h
+++ b/Trampoline.h
@@ -126,8 +126,11 @@ private:
 
 	static void* FindAndAllocateMem( const uintptr_t addr, size_t& size )
 	{
-		// We need to start searching from 0 as in some cases, the place we want to allocate might be BEHIND US.
-		uintptr_t curAddr = 0;
+		// Determine the start point: 2GB before 'addr' or 0, whichever is larger.
+		// In some cases we can only allocate behind us; for example, in x64 processes when
+		// .NET Runtime might reserves a huge memory in front of us up front.
+		const uintptr_t maxRelJump = (static_cast<uintptr_t>(2) * 1024 * 1024 * 1024) - 1; // -1 because signed value for forward jump.
+		uintptr_t curAddr = (addr > maxRelJump) ? (addr - maxRelJump) : 0;
 
 		SYSTEM_INFO systemInfo;
 		GetSystemInfo( &systemInfo );

--- a/Trampoline.h
+++ b/Trampoline.h
@@ -126,7 +126,8 @@ private:
 
 	static void* FindAndAllocateMem( const uintptr_t addr, size_t& size )
 	{
-		uintptr_t curAddr = addr;
+		// We need to start searching from 0 as in some cases, the place we want to allocate might be BEHIND US.
+		uintptr_t curAddr = 0;
 
 		SYSTEM_INFO systemInfo;
 		GetSystemInfo( &systemInfo );
@@ -146,17 +147,32 @@ private:
 				uintptr_t alignedAddr = uintptr_t(MemoryInf.BaseAddress);
 				alignedAddr = (alignedAddr + granularity - 1) & ~uintptr_t(granularity - 1);
 
-				if ( !IsAddressFeasible( alignedAddr, addr ) ) break;
+				uintptr_t alignedAddrEnd = uintptr_t(uintptr_t(MemoryInf.BaseAddress) + MemoryInf.RegionSize) - size;
+				alignedAddrEnd = RoundDown(alignedAddrEnd, granularity);
 
-				LPVOID mem = VirtualAlloc( reinterpret_cast<LPVOID>(alignedAddr), size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE );
-				if ( mem != nullptr )
+				if (IsAddressFeasible(alignedAddr, addr)) 
 				{
-					return mem;
+					LPVOID mem = VirtualAlloc(reinterpret_cast<LPVOID>(alignedAddr), size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+					if (mem != nullptr)
+						return mem;
+				}
+				else if (IsAddressFeasible(alignedAddrEnd, addr))
+				{
+					LPVOID mem = VirtualAlloc(reinterpret_cast<LPVOID>(alignedAddrEnd), size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+					if (mem != nullptr)
+						return mem;
 				}
 			}
 			curAddr += MemoryInf.RegionSize;
 		}
 		return nullptr;
+	}
+
+	static uintptr_t RoundDown( uintptr_t addr, DWORD granularity ) 
+	{
+		return addr >= 0 ? 
+			(addr / granularity) * granularity : 
+			((addr - granularity + 1) / granularity) * granularity;
 	}
 
 	static bool IsAddressFeasible( uintptr_t trampolineOffset, uintptr_t addr )


### PR DESCRIPTION
* Allow allocation at end of free pages, such that regions over 2GB in size that are in sufficient proximity can be allocated inside. 

* Allow allocation / start search BEFORE the start of our executable in Virtual Memory, so mapping pages that come earlier is also possible.

This should fix some cases where e.g. loading the .NET Runtime (which reserves >2GB right after image/exe so it can efficiently allocate sequentially) would prevent the Trampoline allocator from functioning.