### PR TITLE
Patterns: add <string> include to fix MSVC 19.41

### DIFF
--- a/Patterns.h
+++ b/Patterns.h
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <vector>
+#include <string>
 #include <string_view>
 
 #if defined(_CPPUNWIND) && !defined(PATTERNS_SUPPRESS_EXCEPTIONS)


### PR DESCRIPTION
Fixes #13

The <string_view> include might not be needed for MSVC at least, but maybe better to still include it explicitly