### PR TITLE
Cross-compile fixes (part 2)

### DIFF
--- a/HookInit.hpp
+++ b/HookInit.hpp
@@ -66,7 +66,7 @@ static void ReplaceFunction(void** funcPtr)
 	VirtualProtect(funcPtr, sizeof(*funcPtr), PAGE_READWRITE, &dwProtect);
 	wrapped_function::origFunction = **reinterpret_cast<decltype(wrapped_function::origFunction)*>(funcPtr);
 
-	*funcPtr = wrapped_function::Hook;
+	*funcPtr = &wrapped_function::Hook;
 	VirtualProtect(funcPtr, sizeof(*funcPtr), dwProtect, &dwProtect);
 }
 
@@ -127,7 +127,7 @@ static bool PatchIAT_ByPointers()
 	using namespace Memory::VP;
 
 	wrapped_function::origFunction = HOOKED_FUNCTION;
-	memcpy(wrapped_function::origCode, wrapped_function::origFunction, sizeof(wrapped_function::origCode));
+	memcpy(wrapped_function::origCode, reinterpret_cast<void*>(wrapped_function::origFunction), sizeof(wrapped_function::origCode));
 
 #ifdef _WIN64
 	Trampoline* trampoline = Trampoline::MakeTrampoline(wrapped_function::origFunction);

--- a/MemoryMgr.h
+++ b/MemoryMgr.h
@@ -11,9 +11,9 @@
 #ifdef _MSC_VER
 #define EAXJMP(a) { _asm mov eax, a _asm jmp eax }
 #define VARJMP(a) { _asm jmp a }
-#elif defined(__GNUC__) || defined(__clang__)
-#define EAXJMP(a) { __asm__ volatile("mov eax, %0\n" "jmp eax" :: "i" (a)); }
-#define VARJMP(a) { __asm__ volatile("jmp %0" :: "m" (a)); }
+#else
+#define EAXJMP(a) __asm__ volatile("mov eax, %0\n" "jmp eax" :: "i" (a));
+#define VARJMP(a) __asm__ volatile("jmp %0" :: "m" (a));
 #endif
 
 #ifdef _MSC_VER

--- a/MemoryMgr.h
+++ b/MemoryMgr.h
@@ -6,14 +6,15 @@
 
 #define WRAPPER __declspec(naked)
 #define DEPRECATED __declspec(deprecated)
-#define WRAPARG(a) ((int)a)
 
 #ifdef _MSC_VER
 #define EAXJMP(a) { _asm mov eax, a _asm jmp eax }
 #define VARJMP(a) { _asm jmp a }
+#define WRAPARG(a) ((int)a)
 #else
 #define EAXJMP(a) __asm__ volatile("mov eax, %0\n" "jmp eax" :: "i" (a));
 #define VARJMP(a) __asm__ volatile("jmp %0" :: "m" (a));
+#define WRAPARG(a)
 #endif
 
 #ifdef _MSC_VER

--- a/Patterns.cpp
+++ b/Patterns.cpp
@@ -64,7 +64,7 @@ static auto& getHints()
 }
 #endif
 
-static void TransformPattern(std::string_view pattern, std::basic_string<uint8_t>& data, std::basic_string<uint8_t>& mask)
+static void TransformPattern(std::string_view pattern, pattern_string& data, pattern_string& mask)
 {
 	uint8_t tempDigit = 0;
 	bool tempFlag = false;


### PR DESCRIPTION
This adds extra fixes for parts not tested in MR #15 (like Clang support or the HookInit header that's included in the 90s NFS SilentPatch)