### PR TITLE
GCC 14 fixes

### DIFF
--- a/MemoryMgr.h
+++ b/MemoryMgr.h
@@ -135,7 +135,7 @@ namespace Memory
 		return reinterpret_cast<void*>( addr + offset );
 	}
 
-	constexpr auto InterceptCall = [](auto address, auto&& func, auto&& hook)
+	inline auto InterceptCall = [](auto address, auto&& func, auto&& hook)
 	{
 		ReadCall(address, func);
 		InjectHook(address, hook);

--- a/Patterns.h
+++ b/Patterns.h
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
This allows SilentPatchIII to compile again after the GCC 14 update