### PR TITLE
Patterns: allow EnsureMatches to return early after reaching maxCount

### DIFF
--- a/Patterns.cpp
+++ b/Patterns.cpp
@@ -268,7 +268,8 @@ void basic_pattern_impl::EnsureMatches(uint32_t maxCount)
 
 				if (matchSuccess(i))
 				{
-					break;
+					m_matched = true;
+					return;
 				}
 				i++;
 			}


### PR DESCRIPTION
EnsureMatches uses a `matchSuccess()` lambda to check if `maxCount` was reached, then breaks if it was, but the code is nested inside two loops - we break from first loop, then next loop `for (const auto& segment : m_scanSegments)` continues to next segment and tries to scan for same bytes again :/

Doesn't seem intended so changed it to return early instead, doing the same as if it had broken from both loops, but could change it to use some flag instead.

This reduced pattern scans from 15-20 secs to 2 seconds in re4_tweaks (which has way too many pattern scans...)